### PR TITLE
loggen: Fix active task waiting delay

### DIFF
--- a/loggen/__init__.py
+++ b/loggen/__init__.py
@@ -430,8 +430,9 @@ def task_active(ctrl, sock_info, buffer=(),
             'hostname': hostname,
             'msg': msg
         }))
-        if delay > 0:
-            time.sleep(delay / 1000)
+
+        if wait > 0 and not ctrl.shutdown.is_set():
+            time.sleep(wait / 1000)
 
     with suppress(threading.BrokenBarrierError):
         ctrl.done.wait()


### PR DESCRIPTION
The `wait` parameter was changed d486320 but not all usage has been
moved to the new name. This commit fixes the situation.

Signed-off-by: Jimmy Thrasibule <jimmy@thrasibule.mx>